### PR TITLE
Fix reported issue

### DIFF
--- a/cc_tk/feature/correlation.py
+++ b/cc_tk/feature/correlation.py
@@ -211,7 +211,10 @@ class ClusteringCorrelation(TransformerMixin, BaseEstimator):
             Target, by default None
 
         """
-        features_, y = validate_data(self, features, y, ensure_min_features=2)
+        if y is not None:
+            features_, y = validate_data(self, features, y, ensure_min_features=2)
+        else:
+            features_ = validate_data(self, features, y, ensure_min_features=2)
         self.n_features_in_ = features_.shape[1]
         if isinstance(features, pd.DataFrame):
             self._columns = features.columns
@@ -459,9 +462,14 @@ class PairwiseCorrelationDrop(TransformerMixin, BaseEstimator):
             Fitted transformer
 
         """
-        features_, y = validate_data(
-            self, features, y, ensure_min_features=2, ensure_min_samples=2
-        )
+        if y is not None:
+            features_, y = validate_data(
+                self, features, y, ensure_min_features=2, ensure_min_samples=2
+            )
+        else:
+            features_ = validate_data(
+                self, features, y, ensure_min_features=2, ensure_min_samples=2
+            )
         self.n_features_in_ = features_.shape[1]
         self.mask_selection_ = self.compute_mask_selection(
             features_, self.threshold


### PR DESCRIPTION
Fix `ValueError: too many values to unpack` in `ClusteringCorrelation` and `PairwiseCorrelationDrop` by correctly handling the return value of `sklearn.utils.validation.validate_data` when `y` is `None`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf4f6e0d-1cf6-4761-8d1f-b24561a7402b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf4f6e0d-1cf6-4761-8d1f-b24561a7402b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

